### PR TITLE
fix for in for babel 5

### DIFF
--- a/interpret.js
+++ b/interpret.js
@@ -2,7 +2,7 @@ const id = x => x
 
 const find = (xs, f) => {
   var found;
-  for(x in xs) {
+  for(let x in xs) {
     if(f(xs[x])) {
       found = xs[x]
       break;


### PR DESCRIPTION
I change this line:

`for(x in xs)`

to 

`for(let x in xs)`

For running with `babel-node example.js` 
instead of `node --harmony_destructuring example.js`
