### PR TITLE
Dispatch refactor

### DIFF
--- a/example.js
+++ b/example.js
@@ -43,9 +43,9 @@ app.foldMap(runApp, Task.of).fork(console.error, console.log)
 
 // do syntax is much nicer
 gtZero(10)
-.chain(ten =>
-    asyncGet(4).map(four =>
-      ten + four))
+.chain(ten => {
+    return asyncGet(4).map(four => {
+      return ten + four}) })
 .foldMap(runApp, Task.of).fork(console.error, console.log)
 // 14
 

--- a/example.js
+++ b/example.js
@@ -32,20 +32,22 @@ const app = Monad.do(function *() {
 })
 
 // this tells our Free.foldMap how to dispatch. We need all of them to turn into a target monad (in this case Task)
-const runApp = dispatch([ [IOType, ioToTask],
-                          [ContType, contToTask],
-                          [Either, eitherToTask],
-                          [Maybe, maybeToTask]
-                        ])
+const runApp = dispatch(Task.of)
+  ( [ [IOType, ioToTask]
+      , [ContType, contToTask]
+      , [Either, eitherToTask]
+      , [Maybe, maybeToTask]
+    ]
+  )
 
 app.foldMap(runApp, Task.of).fork(console.error, console.log)
 // 10
 
 // do syntax is much nicer
 gtZero(10)
-.chain(ten => {
-    return asyncGet(4).map(four => {
-      return ten + four}) })
+.chain(ten =>
+    asyncGet(4).map(four =>
+      ten + four))
 .foldMap(runApp, Task.of).fork(console.error, console.log)
 // 14
 

--- a/example.js
+++ b/example.js
@@ -34,13 +34,13 @@ const app = Monad.do(function *() {
 // this tells our Free.foldMap how to dispatch. We need all of them to turn into a target monad (in this case Task)
 const runApp = dispatch(Task.of)
   ( [ [IOType, ioToTask]
-      , [ContType, contToTask]
-      , [Either, eitherToTask]
-      , [Maybe, maybeToTask]
+    , [ContType, contToTask]
+    , [Either, eitherToTask]
+    , [Maybe, maybeToTask]
     ]
   )
 
-app.foldMap(runApp, Task.of).fork(console.error, console.log)
+app.foldMap(runApp).fork(console.error, console.log)
 // 10
 
 // do syntax is much nicer
@@ -48,8 +48,8 @@ gtZero(10)
 .chain(ten =>
     asyncGet(4).map(four =>
       ten + four))
-.foldMap(runApp, Task.of).fork(console.error, console.log)
+.foldMap(runApp).fork(console.error, console.log)
 // 14
 
-gtZero(0).chain(() => asyncGet(4)).foldMap(runApp, Task.of).fork(console.error, console.log)
+gtZero(0).chain(() => asyncGet(4)).foldMap(runApp).fork(console.error, console.log)
 // error: it was less than zero

--- a/free.js
+++ b/free.js
@@ -21,7 +21,7 @@ methods.forEach(name => Free.prototype[name] = method(name))
 
 const liftF = command => Free(command, [])
 
-Free.prototype.foldMap = function(interpreter, of) {
+Free.prototype.foldMap = function(interpreter) {
   return this.fs.reduce(interpretStep(interpreter), interpreter(this.x))
 }
 
@@ -31,9 +31,9 @@ const interpretStep = interpreter => (monad, call) => {
 }
 
 const interpreterUses =
-  { 'map': () => id
+  { 'map': _ => id
   , 'ap': f => free => f(free.x)
-  , 'chain': (f, of) => g => a => g(a).foldMap(f, of)
+  , 'chain': f => g => a => g(a).foldMap(f)
   }
 
 const fallback = monad => method =>

--- a/free.js
+++ b/free.js
@@ -1,4 +1,5 @@
 const daggy = require('daggy')
+const fallback = require('fantasy-derivations')
 
 const id = x => x
 
@@ -26,7 +27,7 @@ Free.prototype.foldMap = function(interpreter) {
 }
 
 const interpretStep = interpreter => (monad, call) => {
-  const method = fallback(monad)(call.method)
+  const method = fallback(call.method, monad)
   return method(interpreterUses[call.method](interpreter)(call.arg))
 }
 
@@ -34,14 +35,6 @@ const interpreterUses =
   { 'map': _ => id
   , 'ap': f => free => f(free.x)
   , 'chain': f => g => a => g(a).foldMap(f)
-  }
-
-const fallback = monad => method =>
-  (monad[method] || fallbacks[method](monad)).bind(monad)
-
-const fallbacks =
-  { 'map': m => f => m.chain(a=> (m.of || m.constructor.of)(f(a)))
-  , 'ap': m => m2 => m.chain(f => fallback(m2)('map')(f))
   }
 
 module.exports = { liftF, Free }

--- a/free.js
+++ b/free.js
@@ -25,13 +25,23 @@ Free.prototype.foldMap = function(interpreter, of) {
   return this.fs.reduce(interpretStep(interpreter), interpreter(this.x))
 }
 
-const interpretStep = interpreter => (monad, call) =>
-  monad[call.method](interpreterUses[call.method](interpreter)(call.arg))
+const interpretStep = interpreter => (monad, call) => {
+  const method = fallback(monad)(call.method)
+  return method(interpreterUses[call.method](interpreter)(call.arg))
+}
 
-var interpreterUses =
+const interpreterUses =
   { 'map': () => id
   , 'ap': f => free => f(free.x)
   , 'chain': (f, of) => g => a => g(a).foldMap(f, of)
+  }
+
+const fallback = monad => method =>
+  (monad[method] || fallbacks[method](monad)).bind(monad)
+
+const fallbacks =
+  { 'map': m => f => m.chain(a=> (m.of || m.constructor.of)(f(a)))
+  , 'ap': m => m2 => m.chain(f => fallback(m2)('map')(f))
   }
 
 module.exports = { liftF, Free }

--- a/interpret.js
+++ b/interpret.js
@@ -12,10 +12,10 @@ const find = (xs, f) => {
   return found;
 }
 
-const dispatch = pairs =>
+const dispatch = of => pairs =>
   instruction_of_arg => {
-    const interpreter = find(pairs, xs => // [type, interpreter]
-        instruction_of_arg.constructor === xs[0])[1]
+    const interpreter = (find(pairs, xs => // [type, interpreter]
+        instruction_of_arg.constructor === xs[0]) || [null, of])[1]
 
     return interpreter(instruction_of_arg)
   }

--- a/monad.js
+++ b/monad.js
@@ -1,4 +1,4 @@
-const Free = require('./free').Free
+const lift = require('./free').liftF
 
 const Monad = {
   do: gen => {
@@ -11,7 +11,7 @@ const Monad = {
     }
     return step()
   },
-  of: Free.of
+  of: lift
 }
 
 module.exports = Monad

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "daggy": "0.0.1",
     "data.task": "3.1.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tape": "4.5.1"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --harmony-destructuring test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "daggy": "0.0.1",
-    "data.task": "3.1.0"
+    "data.task": "3.1.0",
+    "fantasy-derivations": "0.0.0"
   },
   "devDependencies": {
     "tape": "4.5.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "daggy": "0.0.1",
-    "data.task": "safareli/data.task.git#patch-1"
+    "data.task": "3.1.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -46,7 +46,7 @@ test('gives us 10', t => {
     return Monad.of(ioNumber + maybeNumber + eitherNumber + contNumber)
   })
 
-  app.foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)("it's 10!")(10))
+  app.foldMap(runApp).fork(t.fail, equalAndEnd(t)("it's 10!")(10))
 })
 
 test('give us 14', t =>
@@ -55,12 +55,12 @@ test('give us 14', t =>
   .chain(ten => {
       return asyncGet(4).map(four => {
         return ten + four}) })
-  .foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)("it's 14")(14))
+  .foldMap(runApp).fork(t.fail, equalAndEnd(t)("it's 14")(14))
 )
 
 test('gives us error string', t => {
   gtZero(0).chain(() => asyncGet(4))
-    .foldMap(runApp, Task.of).fork
+    .foldMap(runApp).fork
       ( equalAndEnd(t)("it failed!")("it was less than zero")
       , t.fail
       )
@@ -70,7 +70,7 @@ test('ap works in parallel', t => {
   t.timeoutAfter(300)
   const second = asyncGet(1)
   const app = second.map(() => () => () => true).ap(second).ap(second)
-  app.foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)('happened fast!')(true))
+  app.foldMap(runApp).fork(t.fail, equalAndEnd(t)('happened fast!')(true))
 })
 
 test('works without ap/map defined', t => {
@@ -78,6 +78,6 @@ test('works without ap/map defined', t => {
   delete Task.prototype.ap
   const second = asyncGet(1)
   const app = second.map(() => () => () => true).ap(second).ap(second)
-  app.foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)('still works!')(true))
+  app.foldMap(runApp).fork(t.fail, equalAndEnd(t)('still works!')(true))
 })
 

--- a/test.js
+++ b/test.js
@@ -1,0 +1,75 @@
+const Task = require('data.task')
+const {IOType, IO} = require('./io')
+const {Either, Left, Right} = require('./either')
+const {Maybe, Just, Nothing} = require('./maybe')
+const {ContType, Cont} = require('./cont')
+const {State} = require('./state')
+const {dispatch} = require('./interpret')
+const Monad = require('./monad')
+const test = require('tape')
+
+// some nt's, but where to stash these?
+const maybeToTask = m => m.fold(Task.of, Task.rejected)
+const contToTask = c => c.t
+const eitherToTask = m => m.fold(Task.rejected, Task.of)
+const ioToTask = i => new Task((rej, res) => res(i.f()))
+
+const equalAndEnd = t => message => expected => actual => {
+  t.equal(actual, expected, message)
+  t.end()
+}
+
+// either Example
+const gtZero = x =>
+  (x > 0) ? Right(x) : Left("it was less than zero")
+
+// cont example (cont just wraps task. prob a misnomer)
+const asyncGet = n =>
+  Cont((rej, res) => setTimeout(() => res(n), 100))
+
+// this tells our Free.foldMap how to dispatch. We need all of them to turn into a target monad (in this case Task)
+const runApp = dispatch(Task.of)
+  ( [ [IOType, ioToTask]
+      , [ContType, contToTask]
+      , [Either, eitherToTask]
+      , [Maybe, maybeToTask]
+    ]
+  )
+
+test('gives us 10', t => {
+  // do syntax works for any 1 monad. Since it's all in Free, we can use multiple
+  const app = Monad.do(function *() {
+    const ioNumber = yield IO(() => 1)
+    const maybeNumber = yield Just(2)
+    const contNumber = yield asyncGet(3)
+    const eitherNumber = yield gtZero(4)
+    return Monad.of(ioNumber + maybeNumber + eitherNumber + contNumber)
+  })
+
+  app.foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)("it's 10!")(10))
+})
+
+test('give us 14', t =>
+  // do syntax is much nicer
+  gtZero(10)
+  .chain(ten => {
+      return asyncGet(4).map(four => {
+        return ten + four}) })
+  .foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)("it's 14")(14))
+)
+
+test('gives us error string', t => {
+  gtZero(0).chain(() => asyncGet(4))
+    .foldMap(runApp, Task.of).fork
+      ( equalAndEnd(t)("it failed!")("it was less than zero")
+      , t.fail
+      )
+})
+
+test('ap works in parallel', t => {
+  t.timeoutAfter(300)
+  const second = asyncGet(1)
+  const app = second.map(() => () => () => true).ap(second).ap(second)
+  app.foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)('happened fast!')(true))
+})
+

--- a/test.js
+++ b/test.js
@@ -30,9 +30,9 @@ const asyncGet = n =>
 // this tells our Free.foldMap how to dispatch. We need all of them to turn into a target monad (in this case Task)
 const runApp = dispatch(Task.of)
   ( [ [IOType, ioToTask]
-      , [ContType, contToTask]
-      , [Either, eitherToTask]
-      , [Maybe, maybeToTask]
+    , [ContType, contToTask]
+    , [Either, eitherToTask]
+    , [Maybe, maybeToTask]
     ]
   )
 
@@ -71,5 +71,13 @@ test('ap works in parallel', t => {
   const second = asyncGet(1)
   const app = second.map(() => () => () => true).ap(second).ap(second)
   app.foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)('happened fast!')(true))
+})
+
+test('works without ap/map defined', t => {
+  delete Task.prototype.map
+  delete Task.prototype.ap
+  const second = asyncGet(1)
+  const app = second.map(() => () => () => true).ap(second).ap(second)
+  app.foldMap(runApp, Task.of).fork(t.fail, equalAndEnd(t)('still works!')(true))
 })
 


### PR DESCRIPTION
A fairly big (breaking*) refactor that allows all monad methods to be dispatched to.

I just use a list of methods to keep track of operations on the free monad (I think this is roughly what it means to be "a (free) monoid in the category of functors", but would be interested to know if that's true or not)

\* The `of` function should now be passed into `dispatch` rather than `foldMap`
