### PR TITLE
Add mapInstruction method 

### DIFF
--- a/free.js
+++ b/free.js
@@ -63,4 +63,14 @@ Free.prototype.foldMap = fixDo(function(interpreter, of) {
   })
 })
 
+Free.prototype.mapInstruction = fixDo(function(f) {
+  return this.cata({
+    Pure: value => Free.Pure(value),
+    Impure: (instruction, next) => Free.Impure(
+      f(instruction),
+      (x) => next(x).mapInstruction(f)
+    )
+  })
+})
+
 module.exports = { liftF, Free, IGNORE_VALUE }

--- a/free.js
+++ b/free.js
@@ -37,18 +37,30 @@ const liftF = command => Free.Impure(command, Free.Pure)
 // Special object which should be ignored.
 const IGNORE_VALUE = {}
 
-Free.prototype.foldMap = function(interpreter, of) {
+const fixDo = function(f) {
+  return function() {
+    const context = this.cata({
+      Pure: (a) => this,
+      Impure: (intruction_of_arg, next) => {
+        if (intruction_of_arg === IGNORE_VALUE) {
+          return next()
+        } else {
+          return this
+        }
+      }
+    })
+    return f.apply(context, arguments)
+  }
+}
+
+Free.prototype.foldMap = fixDo(function(interpreter, of) {
   return this.cata({
     Pure: a => of(a),
-    Impure: (intruction_of_arg, next) => {
-      if (intruction_of_arg === IGNORE_VALUE) {
-        return next().foldMap(interpreter, of)
-      } else {
-        return interpreter(intruction_of_arg).chain(result =>
-          next(result).foldMap(interpreter, of))
-      }
-    }
+    Impure: (intruction_of_arg, next) =>
+      interpreter(intruction_of_arg).chain(result =>
+        next(result).foldMap(interpreter, of)
+      )
   })
-}
+})
 
 module.exports = { liftF, Free, IGNORE_VALUE }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "daggy": "0.0.1",
     "data.task": "safareli/data.task.git#patch-1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "fantasy-identities": "0.0.1",
+    "tape": "4.5.1"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --harmony-destructuring test/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,25 @@
+const Identity = require('fantasy-identities')
+const test = require('tape');
+
+const {Free, liftF} = require('../free.js')
+const Monad = require('../monad.js')
+
+test('Monad.do', t => {
+  const tree = Monad.do(function*(){
+    const a = yield liftF(1)
+    const b = yield liftF(2)
+    return Monad.of([a, b])
+  })
+  t.deepEqual(
+    [
+      tree.foldMap((a) => Identity(a), Identity),
+      tree.foldMap((a) => Identity(a), Identity),
+    ],
+    [
+      Identity([1,2]),
+      Identity([1,2])
+    ],
+    'result of Monad.do should be reusable'
+  )
+  t.end()
+})

--- a/test/test.js
+++ b/test/test.js
@@ -23,3 +23,19 @@ test('Monad.do', t => {
   )
   t.end()
 })
+
+
+test('mapInstruction', t => {
+  const tree = liftF(1).chain(
+    a => liftF(2).chain(
+      b => Free.of([a,b])
+    )
+  )
+
+  t.deepEqual(
+    tree.mapInstruction((a) => a + 2).foldMap((a) => Identity(a), Identity).x,
+    [3,4],
+    'should add 2 to all instructions in Free'
+  )
+  t.end()
+})


### PR DESCRIPTION
Fixes #8
- Abstract logic of fixing `do` notation into decorator, use it with `foldMap` and `mapInstruction`
- Added tests for `Monad.do` and `mapInstruction`
