### PR TITLE
Fixes NPM install error for unknown path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "freeky",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Free monad collection",
   "main": "index.js",
   "dependencies": {
     "daggy": "0.0.1",
-    "data.task": "safareli/data.task.git#patch-1"
+    "data.task": "^3.1.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
NPM is throwing a lovely error (described below) due to the `data.task` package pointing to `safareli/data.task.git#patch-1`

``` bash
npm ERR! git rev-list -n1 patch-1: fatal: ambiguous argument 'patch-1': unknown revision or path not in the working tree.
```

As @safareli pointed on his comment on the related commit:

> This fork is already merged and is published in version 3.1.0 so could change it to ^3.1.0 instead.

So, there you go.
